### PR TITLE
now runnable with ubuntu

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     }
   },
   "bin": {
-    "make-license": "src/index.js"
+    "make-license": "src/index.sh"
   },
   "repository": {
     "type": "git",

--- a/src/index.sh
+++ b/src/index.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+rdlkf() { [ -L "$1" ] && (local lk="$(readlink "$1")"; local d="$(dirname "$1")"; cd "$d"; local l="$(rdlkf "$lk")"; ([[ "$l" = /* ]] && echo "$l" || echo "$d/$l")) || echo "$1"; }
+DIR="$(dirname "$(rdlkf "$0")")"
+exec /usr/bin/env node --harmony "$DIR/index.js" "$@"


### PR DESCRIPTION
The change is like in this case: https://github.com/azproduction/node-mc/issues/3

Maybe a more general solution would be

``` sh
#!/bin/sh
exec node --harmony "$@"
```

source: http://stackoverflow.com/questions/8108917/why-does-passing-arguments-to-the-command-in-an-env-invocation-not-work
