### PR TITLE
Add files property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "make-license",
   "description": "generate a LICENSE for your open source project",
   "main": "src/index.js",
+  "files": [
+    "src"
+  ],
   "scripts": {
     "test": "mocha test/index.test.js -w ",
     "test:single": "istanbul cover -x *.test.js,src/index.js _mocha tests/index.test.js",


### PR DESCRIPTION
By setting the `files` property in package.json to only contain `src`, npm will only distribute the `src` directory (along with all the other necessities such as `README.md`, `LICENSE`). 

It will not distribute all of your test files or your development config files (`.travis.yml`, for example).

This will reduce the total size of the distribution from 12kb to around 5kb. That's a saving of over 50%.
