### PR TITLE
Fix wrong path

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "src"
   ],
   "scripts": {
-    "test": "mocha test/index.test.js -w ",
+    "test": "mocha tests/index.test.js -w ",
     "test:single": "istanbul cover -x *.test.js,src/index.js _mocha tests/index.test.js",
     "commit": "git-cz",
     "report-coverage": "cat ./coverage/lcov.info | codecov",


### PR DESCRIPTION
The directory containing the `index.test.js` is `tests/` and not `test/`.
